### PR TITLE
Introduce basic python 3 compatibility

### DIFF
--- a/glogcli/cli.py
+++ b/glogcli/cli.py
@@ -91,7 +91,7 @@ def run(version,
         sr.from_time = arrow.now().replace(seconds=-latency - 1)
         sr.to_time = arrow.now().replace(seconds=-latency)
 
-    limit = None if limit <= 0 else limit
+    limit = None if (limit or 0) <= 0 else limit
     fields = fields if mode == 'dump' else utils.extract_fields_from_format(cfg, format_template)
     color = get_color_option(cfg, format_template, no_color)
 

--- a/glogcli/formats.py
+++ b/glogcli/formats.py
@@ -18,7 +18,10 @@ class Formatter(object):
         raise NotImplementedError()
 
     def encode_message(self, message):
-        return message.encode('utf8')
+        if six.PY3:
+            return message
+        else:
+            return message.encode('utf8')
 
 
 class TailFormatter(Formatter):

--- a/glogcli/output.py
+++ b/glogcli/output.py
@@ -1,14 +1,15 @@
 from __future__ import division, print_function
 import time
 import arrow
+from six import PY2, PY3
 from glogcli.graylog_api import SearchRange
 from glogcli.utils import LOCAL_TIMEZONE
 
 import sys
 
-reload(sys)
-sys.setdefaultencoding('utf8')
-
+if PY2:
+    reload(sys)
+    sys.setdefaultencoding('utf8')
 
 class SimpleBuffer(object):
 
@@ -66,14 +67,27 @@ class LogPrinter(object):
 
             formatted_msgs.reverse()
 
-            if formatted_msgs:
-                if output is None:
-                    for msg in formatted_msgs:
-                        print(msg.encode('utf-8').strip())
-                else:
-                    if isinstance(output, basestring):
-                        with open(output, "a") as f:
-                            f.writelines(('\n'.join(formatted_msgs) + '\n').encode('utf-8').strip())
+
+            if PY3:
+                if formatted_msgs:
+                    if output is None:
+                        for msg in formatted_msgs:
+                            print(msg.strip())
                     else:
-                        output.writelines(('\n'.join(formatted_msgs) + '\n').encode('utf-8').strip())
+                        if isinstance(output, basestring):
+                            with open(output, "a") as f:
+                                f.writelines(('\n'.join(formatted_msgs) + '\n').strip())
+                        else:
+                            output.writelines(('\n'.join(formatted_msgs) + '\n').strip())
+            else:    
+                if formatted_msgs:
+                    if output is None:
+                        for msg in formatted_msgs:
+                            print(msg.encode('utf-8').strip())
+                    else:
+                        if isinstance(output, basestring):
+                            with open(output, "a") as f:
+                                f.writelines(('\n'.join(formatted_msgs) + '\n').encode('utf-8').strip())
+                        else:
+                            output.writelines(('\n'.join(formatted_msgs) + '\n').encode('utf-8').strip())
             return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ flake8==2.6.0
 tox==2.3.1
 coverage==4.1
 Sphinx==1.4.4
-click>=3.3,<7
+click>=3.3,<=7.3
 keyring==8.7
 parsedatetime>=1.4,<3
 python-dateutil>=2.4.1,<3
@@ -13,6 +13,6 @@ requests>=2.4.3,<3.0
 arrow>=0.5.4,<0.8
 termcolor==1.1.0
 six>=1.9.0
-pytest==2.9.2
+pytest>=2.9.2,<=5.3
 mock==1.3.0
 httpretty==0.8.14

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 install_requires = [
-    'click>=3.3,<7',
+    'click>=3.3,<=7.3',
     'keyring==8.7',
     'parsedatetime>=1.4,<3',
     'python-dateutil>=2.4.1,<3',
@@ -25,7 +25,7 @@ tests_require = [
     'coverage==4.1',
     'httpretty==0.8.14',
     'mock==1.3.0',
-    'pytest==2.9.2',
+    'pytest>=2.9.2,<=5.3',
 ]
 
 setup_requires = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, py36, flake8
+envlist = py27, py33, py34, py35, py36, py37, py38, flake8
 
 [testenv:flake8]
 commands=python setup.py flake8


### PR DESCRIPTION
Skip some string/message encoding if we're on python 3.

Works with `--no-tls`.